### PR TITLE
Remove unused $matched-bg variable from tokens

### DIFF
--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -7,7 +7,6 @@ $accent-2: #2de1c2;
 $text: #e9ecff;
 $muted: rgba(#b9c0ff, .6);
 $ring: #9fb4ff;
-$matched-bg: rgba($accent-2, .33);
 
 $space-1: .25rem;
 $space-2: .5rem;


### PR DESCRIPTION
Deleted the $matched-bg SCSS variable from _tokens.scss as it is no longer used in the codebase.